### PR TITLE
fix: INT_CANCEL in DB-Lib error handler, macOS Homebrew opt paths, dbopen diagnostics

### DIFF
--- a/lib/src/ffi/freetds_bindings.dart
+++ b/lib/src/ffi/freetds_bindings.dart
@@ -673,7 +673,9 @@ int _dartDbErrHandler(
       '${safeFromUtf8(dberrstr)}'
       '${oserrstr == nullptr ? '' : ' | ${safeFromUtf8(oserrstr)}'}';
   _DbLibErrorStore.setLastError(dbproc, msg);
-  return 0; // per DB-Lib docs, return value ignored
+  // Return INT_CANCEL (2) so DB-Lib returns FAIL from the failing API call
+  // instead of calling exit(). Returning INT_EXIT (0) would kill the process.
+  return 2;
 }
 
 int _dartDbMsgHandler(
@@ -713,8 +715,11 @@ int _dartDbMsgHandler(
 }
 
 // Exposed pointers for installation; keep them alive for the process lifetime.
+// The second arg to Pointer.fromFunction is the exceptional return value used
+// when the Dart callback throws. Use INT_CANCEL (2) for the error handler so
+// DB-Lib always gets CANCEL rather than INT_EXIT (0) which would kill the process.
 final Pointer<NativeFunction<_errHandlerSigC>> kErrHandlerPtr =
-    Pointer.fromFunction<_errHandlerSigC>(_dartDbErrHandler, 0);
+    Pointer.fromFunction<_errHandlerSigC>(_dartDbErrHandler, 2);
 final Pointer<NativeFunction<_msgHandlerSigC>> kMsgHandlerPtr =
     Pointer.fromFunction<_msgHandlerSigC>(_dartDbMsgHandler, 0);
 

--- a/lib/src/mssql_client.dart
+++ b/lib/src/mssql_client.dart
@@ -141,7 +141,9 @@ class MssqlClient {
       }
 
       if (_dbproc == nullptr) {
-        MssqlLogger.e('connect | op=dbopen | server=$server | error=nullptr');
+        final dberr = DBLib.takeLastError(nullptr) ?? DBLib.takeLastError(null) ?? 'none';
+        final dbmsg = DBLib.takeLastMessage(nullptr) ?? DBLib.takeLastMessage(null) ?? 'none';
+        MssqlLogger.e('connect | op=dbopen | server=$server | error=nullptr | dberr=$dberr | dbmsg=$dbmsg');
         return false;
       }
 

--- a/lib/src/native_loader.dart
+++ b/lib/src/native_loader.dart
@@ -364,12 +364,16 @@ class NativeLoader {
   }
 
   /// Builds a list of candidate dylib paths for macOS.
-  /// Tries bare names first (system), then Homebrew paths for Apple Silicon
-  /// (/opt/homebrew/lib) and Intel (/usr/local/lib).
+  /// Tries bare names first (system), then Homebrew formula paths and lib dirs
+  /// for Apple Silicon (/opt/homebrew) and Intel (/usr/local).
+  /// The formula-specific opt/ paths are tried first because /opt/homebrew/lib
+  /// contains symlinks that the App Sandbox may block; bundled apps should copy
+  /// the actual dylibs from opt/.
   static List<String> _buildMacOSPaths(List<String> names) {
     final paths = <String>[...names];
-    for (final dir in ['/opt/homebrew/lib', '/usr/local/lib']) {
-      for (final n in names) paths.add('$dir/$n');
+    for (final prefix in ['/opt/homebrew', '/usr/local']) {
+      for (final n in names) paths.add('$prefix/opt/freetds/lib/$n');
+      for (final n in names) paths.add('$prefix/lib/$n');
     }
     return paths;
   }


### PR DESCRIPTION
## Problem

Three bugs found while integrating `mssql_connection` v3 in a Flutter desktop app on macOS with App Sandbox enabled:

### 1. Critical: Process killed on any connection error (INT_EXIT)

`_dartDbErrHandler` in `freetds_bindings.dart` returned `0` (= `INT_EXIT`).  
Per [FreeTDS DB-Lib docs](https://www.freetds.org/userguide/dblib_errors.html), the return value controls what DB-Lib does after calling the error handler:
- `INT_EXIT (0)` → DB-Lib calls `exit()`, **killing the entire process**
- `INT_CANCEL (2)` → DB-Lib returns `FAIL` from the failing API call (graceful)

The result was that any failed connection attempt (wrong password, unreachable host, network timeout) crashed the entire Flutter app instead of returning `false` from `connect()`.

The same issue applies to `Pointer.fromFunction`'s exceptional return value — if the Dart callback ever throws, the value `0` was being returned to DB-Lib, again causing `exit()`.

### 2. macOS: missing Homebrew formula `opt/` paths

`_buildMacOSPaths` only searched `/opt/homebrew/lib` (symlink directory).  
Homebrew actually installs FreeTDS at `/opt/homebrew/opt/freetds/lib/` (the formula path). While the symlinks in `lib/` normally work, build scripts and sandboxed apps need the actual file path.

### 3. Poor diagnostics after `dbopen` returns `nullptr`

When `dbopen` returned `nullptr`, the log only said `error=nullptr` with no detail. FreeTDS had already fired the error handler with the actual message, but it was discarded. Now we capture and log `dberr` and `dbmsg` from `_DbLibErrorStore`.

## Changes

- **`lib/src/ffi/freetds_bindings.dart`**: Return `2` (INT_CANCEL) instead of `0` (INT_EXIT) in `_dartDbErrHandler`. Update `Pointer.fromFunction` exceptional return from `0` to `2`.
- **`lib/src/native_loader.dart`**: `_buildMacOSPaths` now searches `opt/freetds/lib/` before the generic `lib/` symlink dirs on both Apple Silicon and Intel.
- **`lib/src/mssql_client.dart`**: Log `dberr` and `dbmsg` from the error handler store when `dbopen` returns `nullptr`.

## Testing

Verified on macOS 14 (Apple Silicon) with App Sandbox enabled in a Flutter desktop app. Before fix: app crashed silently on failed connection. After fix: `connect()` returns `false` with a meaningful error log.